### PR TITLE
Replace #pragma message directives with comments

### DIFF
--- a/fastcluster_dm.cpp
+++ b/fastcluster_dm.cpp
@@ -47,9 +47,10 @@
 #define NO_INCLUDE_FENV
 #endif
 #ifdef NO_INCLUDE_FENV
-#pragma message("Do not use fenv header.")
+// fenv header excluded (old MSVC or software floating-point emulation)
 #else
-#pragma message("Use fenv header. If there is a warning about unknown #pragma STDC FENV_ACCESS, this can be ignored.")
+// If there is a warning about unknown #pragma STDC FENV_ACCESS, it can be
+// safely ignored.
 #pragma STDC FENV_ACCESS on
 #include <fenv.h>
 #endif


### PR DESCRIPTION
## Summary

- Replace two `#pragma message` directives in `fastcluster_dm.cpp` (lines 50, 52) with equivalent comments

## Motivation

The two `#pragma message` directives emit informational notes on every compilation:

```
fastcluster_dm.cpp:50: note: #pragma message: Do not use fenv header.
fastcluster_dm.cpp:52: note: #pragma message: Use fenv header. ...
```

These were useful during development to indicate which fenv code path was taken, but they produce noise for downstream consumers that vendor this library. For example, [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) fetches hclust-cpp via CMake FetchContent, and these messages appear on every build with no actionable information for the user.

GCC always prints `#pragma message` output and provides no flag to suppress it (unlike `#pragma warning` on MSVC), so the only fix is at the source.

## Change

The `#pragma message` directives are replaced with comments that preserve the original intent (documenting when fenv is/isn't included) without generating build output. No functional change — the `#ifdef NO_INCLUDE_FENV` logic, `#pragma STDC FENV_ACCESS on`, and `#include <fenv.h>` are all unchanged.

Requested by @csukuangfj in https://github.com/k2-fsa/sherpa-onnx/pull/3216#discussion_r2111485919.